### PR TITLE
feat: Improve Kurtosis packages search

### DIFF
--- a/server/crawler/kurtosis_package_locator.go
+++ b/server/crawler/kurtosis_package_locator.go
@@ -1,0 +1,19 @@
+package crawler
+
+import "github.com/google/go-github/v54/github"
+
+type KurtosisPackageLocator struct {
+	Repository *github.Repository
+
+	RootPath string
+
+	KurtosisYamlFileName string
+}
+
+func NewKurtosisPackageLocator(repository *github.Repository, rootPath string, kurtosisYamlFileName string) *KurtosisPackageLocator {
+	return &KurtosisPackageLocator{
+		Repository:           repository,
+		RootPath:             rootPath,
+		KurtosisYamlFileName: kurtosisYamlFileName,
+	}
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	go.starlark.net v0.0.0-20230814145427-12f4cb8177e4
+	golang.org/x/oauth2 v0.11.0
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -27,7 +28,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.12.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
-	golang.org/x/oauth2 v0.11.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect


### PR DESCRIPTION
It is now able to spot `kurtosis.yml` files not at the root of the repo, and it also doesn't require the kurtosis-package tag on the repo.
The caveat is that it requires a valid Github token as it is impossible to run a search via Github API without being authenticated