### PR TITLE
feat: Filter out packages with invalid name in `kurtosis.yml`

### DIFF
--- a/kurtosis/kurtosis.yml
+++ b/kurtosis/kurtosis.yml
@@ -1,3 +1,3 @@
-name: github.com/kurtosis-tech/kurtosis-package-indexer
+name: github.com/kurtosis-tech/kurtosis-package-indexer/kurtosis
 description: |
   Kurtosis package to run Kurtosis Package Indexer within an enclave


### PR DESCRIPTION
The following packages will be excluded:
- github.com/gobitfly/eth2-beaconchain-explorer/local-deployment
- github.com/codelinkio/moveandwhap
- github.com/vacp2p/wakurtosis
- github.com/mieubrisse/my-kurtosis-package