### PR TITLE
fix: The docker compose package arguments should all be optional

### DIFF
--- a/server/crawler/crawler.go
+++ b/server/crawler/crawler.go
@@ -816,7 +816,7 @@ func extractArgumentsFromEnvFileContent(envFileContent *github.RepositoryContent
 				InnerType1: nil,
 				InnerType2: nil,
 			},
-			IsRequired: true,
+			IsRequired: false,
 			DefaultValue: &val,
 		}
 		envFileArguments[index] = arg


### PR DESCRIPTION
The values from the env file are used as default when the docker compose is converted to a Kurtosis Starlark package so we should make the arguments returned by the indexer optional.