### PR TITLE
fix: setting default docker image for CI remote docker setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ parameters:
     default: "1.19"
   docker-engine-version:
     type: string
-    default: "20.10.7"
+    default: default
   ui-node-version:
     type: string
     default: 18.19.0


### PR DESCRIPTION
Because the current image version is deprecated: https://app.circleci.com/pipelines/github/kurtosis-tech/kurtosis-package-indexer/611/workflows/c4c8871d-74f8-4733-91d2-21e4d007e08b/jobs/1181