### PR TITLE
feat: specify locator in kurtosis package content

### DIFF
--- a/server/crawler/kurtosis_package_content.go
+++ b/server/crawler/kurtosis_package_content.go
@@ -40,6 +40,9 @@ type KurtosisPackageContent struct {
 
 	// RunCount represents the package run count provided by the Kurtosis metrics storage (currently Snowflake)
 	RunCount uint32
+
+	// The locator that can be used from within a Starlark script to run this package
+	Locator string
 }
 
 func NewKurtosisPackageContent(
@@ -53,6 +56,7 @@ func NewKurtosisPackageContent(
 	version string,
 	iconURL string,
 	runCount uint32,
+	locator string,
 	packageArguments ...*StarlarkFunctionArgument,
 ) *KurtosisPackageContent {
 	return &KurtosisPackageContent{
@@ -67,5 +71,6 @@ func NewKurtosisPackageContent(
 		Version:               version,
 		IconURL:               iconURL,
 		RunCount:              runCount,
+		Locator:               locator,
 	}
 }


### PR DESCRIPTION
Specifies the `locator` in `KurtosisPackageContent`. This enables returning both Kurtosis package locators AND Docker Compose locators that end in `compose.yml`. 

This will be used by the Enclave Builder to indicate the correct locator to run Docker Compose scripts.